### PR TITLE
allow_binary_response_format

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -5,7 +5,8 @@ defmodule OpenAI.Client do
 
   def process_url(url), do: Config.api_url() <> url
 
-  def process_response_body(body), do: Jason.decode(body)
+  def process_response_body(body) when is_map(body), do: Jason.decode(body)
+  def process_response_body(body) when is_binary(body), do: body
 
   def handle_response(httpoison_response) do
     case httpoison_response do
@@ -16,6 +17,9 @@ defmodule OpenAI.Client do
           |> Map.new()
 
         {:ok, res}
+        
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, body}        
 
       {:ok, %HTTPoison.Response{body: {:ok, body}}} ->
         {:error, body}


### PR DESCRIPTION
Allow binary response format for Audio Transcription with response format "vtt".

How to test error:

    OpenAI.audio_transcription(
      "my_video.mp4",
      model: "whisper-1",
      response_format: "vtt",
      language: "en",
      temperature: "0"
    )